### PR TITLE
refactor: migrate off Planetscale

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,9 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider     = "mysql"
-  url          = env("DATABASE_URL")
-  relationMode = "prisma"
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Profile {
@@ -39,7 +39,7 @@ model Game {
 }
 
 model BetaUserRequest {
-  id          String  @default(cuid())
+  id          String  @id @default(cuid())
   email       String  @unique
   name        String
   inDashboard Boolean @default(false)


### PR DESCRIPTION
migrate database from Planetscale to Supabase

**steps taken:**
- get data from Planetscale
  - `pscale database dump heardupe main`
- start Supabase project
- update `DATABASE_URL`and add `DIRECT_URL`
- create tables in Supabase
  - `npx prisma db push`
- import data by running the dumped insert queries in Supabase SQL Editor

**resources:**
[Supabase with Prisma](https://supabase.com/partners/integrations/prisma)
[PlanetScale killed their hobby plan (and how to migrate off)](https://www.youtube.com/watch?v=9K5Hi03AJJ4&t=222s)